### PR TITLE
fix: disable autoloadTsconfig to prevent JSX runtime conflicts

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,7 +19,7 @@ const result = await Bun.build({
     outfile: "./dist/ralph",
     autoloadBunfig: false, // Ignore bunfig.toml in user's CWD (preloads don't work in compiled exes)
     // @ts-expect-error - These options exist at runtime but aren't in the types yet
-    autoloadTsconfig: true,
+    autoloadTsconfig: false, // JSX is pre-compiled by solidPlugin; don't pick up user's tsconfig
     autoloadPackageJson: true,
   },
 });


### PR DESCRIPTION
## Summary
- Disable `autoloadTsconfig` in build script to prevent the compiled binary from picking up the user's tsconfig.json at runtime

## Problem
When running ralph from directories with their own `tsconfig.json` (e.g., projects using `@opentui/react`), the runtime was loading that project's `jsxImportSource` instead of using the pre-compiled Solid JSX, causing:
```
error: Cannot find module '@opentui/react/jsx-dev-runtime'
```

## Solution
Since `solidPlugin` already transforms JSX during build, there's no need to load any tsconfig at runtime. Setting `autoloadTsconfig: false` prevents inheriting the user's project configuration.