### PR TITLE
fix: disable autoloadTsconfig to prevent JSX runtime conflicts

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,7 +19,7 @@ const result = await Bun.build({
     outfile: "./dist/ralph",
     autoloadBunfig: false, // Ignore bunfig.toml in user's CWD (preloads don't work in compiled exes)
     // @ts-expect-error - These options exist at runtime but aren't in the types yet
-    autoloadTsconfig: true,
+    autoloadTsconfig: false, // JSX is pre-compiled by solidPlugin; don't pick up user's tsconfig
     autoloadPackageJson: true,
   },
 });


### PR DESCRIPTION
When running the compiled binary from directories with their own tsconfig.json (e.g., projects using @opentui/react), the runtime was picking up the user's jsxImportSource instead of using the pre-compiled Solid JSX.

Since solidPlugin already transforms JSX during build, there's no need to load any tsconfig at runtime. This prevents module resolution errors like: 'Cannot find module @opentui/react/jsx-dev-runtime'